### PR TITLE
userPersonify should expect params, but treats as string containg screen_name

### DIFF
--- a/tests/personifySpecs.js
+++ b/tests/personifySpecs.js
@@ -49,7 +49,7 @@ describe('All methods are working', function(){
 
   xit('personify.homePersonify function should work', function(done){ 
     var personify = new Personify(config);
-    personify.homePersonify('@test', function(data, err) {
+    personify.homePersonify({screen_name: '@test'}, function(data, err) {
       if(err) throw err;
       done();
     }); 

--- a/util/twitter.js
+++ b/util/twitter.js
@@ -26,9 +26,9 @@ var Personify = function(auth) {
   // ========= Watson User Modeling and Twitter REST below =============================
 
   // Takes a twitter handle and return personality traits, needs and values in a JSON object
-  Personify.prototype.userPersonify = function(twitterHandle, callback) {
+  Personify.prototype.userPersonify = function(params, callback) {
 
-    T.get('statuses/user_timeline', { screen_name: twitterHandle, count: 100 },
+    T.get('statuses/user_timeline', params,
         function(err, data, response) {
           if (data.length) {
             for (var i = 0; i < data.length; i++){


### PR DESCRIPTION
The userPersonify method should expect an object as it's first argument and pass that to Twit library, as per test. Currently it assumes a string and assigns that to the screen_name property.

Similarly, homePersonify test fixed to match the current behavior.